### PR TITLE
Quick fix i18n

### DIFF
--- a/gui/assets/locales/en/translation.json
+++ b/gui/assets/locales/en/translation.json
@@ -83,9 +83,12 @@
   "AdminPanel": {
     "Services": "Services"
   },
+  "TableListStep": {
+    "Imported tables": "Imported tables"
+  },
   "FileLoadStep": {
     "Click or drag a file to this area": "Click or drag a file to this area",
-    "Import data": "Import data",
+    "Import table": "Import table",
     "From CSV file": "From CSV file",
     "{{lastCompletedImport}} imported successfully. Click or drag another file to this area": "{{lastCompletedImport}} imported successfully. Click or drag another file to this area"
   },

--- a/gui/src/FileLoadStep/FileLoadStep.tsx
+++ b/gui/src/FileLoadStep/FileLoadStep.tsx
@@ -36,7 +36,7 @@ export const FileLoadStep: FunctionComponent<FileLoadStepProps> = ({ children })
     <>
       <div className="FileLoadStep admin-panel-step">
         <AdminPanelNavAnchor step={AdminPanelNavStep.CsvImport} status={file ? 'done' : 'active'} />
-        <Title level={3}>{t('Import data')}</Title>
+        <Title level={3}>{t('Import table')}</Title>
         <Dragger
           accept=".csv,.tsv,.txt"
           fileList={[]}

--- a/gui/src/TableListStep/TableListStep.tsx
+++ b/gui/src/TableListStep/TableListStep.tsx
@@ -100,7 +100,7 @@ export const TableListStep: FunctionComponent<TableListStepProps> = ({ children 
       const loading = computedResult.state !== 'completed';
       return (
         <>
-          <Title level={3}>{t('Import data')}</Title>
+          <Title level={3}>{t('Imported tables')}</Title>
           <TableList result={cachedResult} loading={loading} invalidateTableList={invalidateTableList} t={t} />
           {/* Render next step */}
           {


### PR DESCRIPTION
In anticipation of the rework to non-i18n, I quick-fixed the i18n stuff, while I was familiarizing myself with how unwieldy i18n is (quite a bit, actually :(... ).

Whether we stick with i18n or not, this at least gives us a baseline without the `::` floating around.

I also factored in the 2 fixes to wording Paul suggested.