### PR TITLE
Fix pg_diffix build steps.

### DIFF
--- a/gui/build.win.js
+++ b/gui/build.win.js
@@ -99,13 +99,13 @@ const metabaseUrl = 'https://downloads.metabase.com/v0.44.4/metabase.jar';
       .trim();
     console.log('Using VS build tools from: ' + vsPath);
 
-    childProcess.execSync(`"${path.join(vsPath, vcvarsPath)}" && msbuild -p:Configuration=Release`, {
-      cwd: 'pg_diffix',
-      env: { PGROOT: path.join('..', pgroot) },
-    });
+    childProcess.execSync(
+      `"${path.join(vsPath, vcvarsPath)}" && SET "PGROOT=..\\${pgroot}" && msbuild -p:Configuration=Release`,
+      { cwd: 'pg_diffix' },
+    );
 
     console.log('Installing pg_diffix...');
-    childProcess.execSync('install.bat Release', { cwd: 'pg_diffix', env: { PGROOT: path.join('..', pgroot) } });
+    childProcess.execSync(`SET "PGROOT=..\\${pgroot}" && install.bat Release`, { cwd: 'pg_diffix' });
 
     console.log('Bundling Metabase...');
     childProcess.execSync(`${jpackagePath} --type app-image -i ${metabaseJarDir} -n metabase --main-jar metabase.jar`);


### PR DESCRIPTION
This bug was causing `msbuild` to fail to find right build tools and took me some time to figure out: setting the `env` parameter when executing a command replaces all the environment variables (instead of adding to them). Some of the critical ones get reset later down the pipeline and things mostly work, which makes it all the harder to figure out what the problem is.