### PR TITLE
Fix and simplify location of stored data.

### DIFF
--- a/gui/scripts/teardown.cmd
+++ b/gui/scripts/teardown.cmd
@@ -4,7 +4,7 @@ setlocal
 
 set LOCAL_PG_BIN=%~dp0..\pgsql\bin
 set PATH=%PATH%;%LOCAL_PG_BIN%
-set DIFFIX_DASHBOARDS_DATA="%appdata%\Local\Diffix Dashboards\data"
+set DIFFIX_DASHBOARDS_DATA="%appdata%\Diffix Dashboards\data"
 set DIFFIX_DASHBOARDS_POSTGRES="%DIFFIX_DASHBOARDS_DATA%\postgres"
 
 pg_ctl -w -D "%DIFFIX_DASHBOARDS_POSTGRES%" stop

--- a/gui/src/main/config.ts
+++ b/gui/src/main/config.ts
@@ -6,9 +6,7 @@ import { productName } from '../../package.json';
 export const isWin = process.platform === 'win32';
 export const isMac = process.platform === 'darwin';
 
-export const appDataLocation = isWin
-  ? path.join(app.getPath('appData'), 'Local', productName, 'data')
-  : path.join(app.getPath('appData'), productName, 'data');
+export const appDataLocation = path.join(app.getPath('userData'), 'data');
 export const appResourcesLocation = path.join(app.getAppPath(), app.isPackaged ? '..' : '.');
 
 // Some of these need to be kept in sync with `init.sql`.


### PR DESCRIPTION
On Windows, `appData` points to `%HOME%\AppData\Roaming`, which is the location of user data that gets synchronized between different systems. System local data is stored in `%HOME%\AppData\Local`.
Previous code was producing the wrong path `%HOME%\AppData\Roaming\Local\Diffix Dashboards\data`.

For simplicity, the location of stored data is moved to application folder.