### PR TITLE
Quote columns when creating destination table during import.

### DIFF
--- a/gui/src/main.ts
+++ b/gui/src/main.ts
@@ -419,7 +419,7 @@ function setupIPC() {
       return runTask(taskId, async (signal) => {
         console.info(`(${taskId}) copying CSV "${fileName}" to "${tableName}".`);
 
-        const columnsSQL = columns.map((column) => `${column.name} ${column.type}`).join(', ');
+        const columnsSQL = columns.map((column) => `"${column.name}" ${column.type}`).join(', ');
         console.info(`Table schema: ${columnsSQL}.`);
 
         try {


### PR DESCRIPTION
Allows us to support column names with spaces, etc.