### PR TITLE
Move message toast to bottom

### DIFF
--- a/gui/src/App/App.css
+++ b/gui/src/App/App.css
@@ -43,3 +43,8 @@ body {
 .text-center {
   text-align: center;
 }
+
+.ant-message {
+  bottom: 20px;
+  top: initial;
+}


### PR DESCRIPTION
Closes #103 .

I tried using `transitionName` to make the toast slide in from bottom to top now, but no matter how I turned it around it didn't work... it's also not documented, so maybe let's leave it alone, it looks quite good.

