### PR TITLE
Clean and reword for a minimalistic in-app documentation

### DIFF
--- a/gui/assets/locales/en/translation.json
+++ b/gui/assets/locales/en/translation.json
@@ -63,39 +63,29 @@
   "ImportDataTab": {
     "Sidebar": {
       "ImportDataNavSteps": {
-        "Services": "Services",
-        "View status of depending services": "View status of depending services",
-        "Table List": "Table List",
-        "Inspect and manage imported tables": "Inspect and manage imported tables",
-        "CSV Import": "CSV Import",
+        "Select File": "Select File",
         "Load data from CSV": "Load data from CSV",
         "Data Preview": "Data Preview",
-        "Preview contents of file": "Preview contents of file",
-        "ID Selection": "ID Selection",
-        "Select the entity identifier column": "Select the entity identifier column",
-        "Import": "Import",
-        "Finalize import": "Finalize import"
-      },
-      "TableListHelp": {
-        "Table List": "Table List",
-        "Inspect and manage the imported tables.<br/><2>Click here for details.</2>": "Inspect and manage the imported tables.<br/><2>Click here for details.</2>"
-      },
-      "ServicesHelp": {
-        "Services": "Services",
-        "View status of depending services.<br/><2>Click here for details.</2>": "View status of depending services.<br/><2>Click here for details.</2>"
+        "Preview contents of the file": "Preview contents of the file",
+        "Protected Entity": "Protected Entity",
+        "Identify the protected entity in the data": "Identify the protected entity in the data",
+        "Table Name": "Table Name",
+        "Select table name and finalize import": "Select table name and finalize import"
       },
       "AidSelectionHelp": {
-        "ID Selection": "ID Selection",
+        "Protected Entity": "Protected Entity",
         "<strong>WARNING:</strong> If this configuration is not done correctly, the data will not be properly anonymized.": "<strong>WARNING:</strong> If this configuration is not done correctly, the data will not be properly anonymized.",
-        "If the data has one row per person (or other <1>protected entity</1>), then no entity identifier column need be selected. Otherwise, select a column containing a unique ID per protected entity. TODO: link docs": "If the data has one row per person (or other <1>protected entity</1>), then no entity identifier column need be selected. Otherwise, select a column containing a unique ID per protected entity. TODO: link docs"
+        "If the data has one row per person (or other <1>protected entity</1>), then no entity identifier column need be selected. Otherwise, select a column containing a unique ID per protected entity.": "If the data has one row per person (or other <1>protected entity</1>), then no entity identifier column need be selected. Otherwise, select a column containing a unique ID per protected entity.",
+        "If the data is not associated with any protected entities, it can be imported into a public table. Such data will not be anonymized.": "If the data is not associated with any protected entities, it can be imported into a public table. Such data will not be anonymized."
       },
       "ImportHelp": {
-        "Import": "Import",
-        "Finalize import into the database. TODO: link docs": "Finalize import into the database. TODO: link docs"
+        "Table Name": "Table Name",
+        "Select a name for the imported table.": "Select a name for the imported table.",
+        "<strong>Diffix Dashboards</strong> will propose a name based on the CSV file name, adjusting it to match the requirements of the underlying database. You may override the proposed name.": "<strong>Diffix Dashboards</strong> will propose a name based on the CSV file name, adjusting it to match the requirements of the underlying database. You may override the proposed name."
       },
       "CsvImportHelp": {
-        "CSV Import": "CSV Import",
-        "<strong>Diffix Dashboards</strong> auto-detects the CSV delimiter, as well as the field type (text and numeric).<br/><3>Click here for details.</3>": "<strong>Diffix Dashboards</strong> auto-detects the CSV delimiter, as well as the field type (text and numeric).<br/><3>Click here for details.</3>"
+        "Select File": "Select File",
+        "<strong>Diffix Dashboards</strong> auto-detects the CSV delimiter, as well as the field type (text, numeric and timestamp).": "<strong>Diffix Dashboards</strong> auto-detects the CSV delimiter, as well as the field type (text, numeric and timestamp)."
       },
       "DataPreviewHelp": {
         "Data Preview": "Data Preview",
@@ -104,8 +94,7 @@
     },
     "FileLoadStep": {
       "Click or drag a file to this area": "Click or drag a file to this area",
-      "Import table": "Import table",
-      "From CSV file": "From CSV file",
+      "Select CSV file": "Select CSV file",
       "{{lastCompletedImport}} imported successfully. Click or drag another file to this area": "{{lastCompletedImport}} imported successfully. Click or drag another file to this area"
     },
     "SchemaLoadStep": {
@@ -120,13 +109,13 @@
       "One row per protected entity": "One row per protected entity",
       "Multiple rows per protected entity": "Multiple rows per protected entity",
       "Select the protected entity ID column": "Select the protected entity ID column",
-      "[Auto-generated row index column]": "[Auto-generated row index column]",
       "NOTICE:": "NOTICE:",
       "File will be imported into a public table. Data contained within will not be anonymized.": "File will be imported into a public table. Data contained within will not be anonymized.",
       "CAUTION:": "CAUTION:",
       "You must ensure that each individual row from the input file represents a unique protected entity.": "You must ensure that each individual row from the input file represents a unique protected entity."
     },
     "ImportStep": {
+      "Select a name for the table": "Select a name for the table",
       "Import": "Import",
       "Table name": "Table name",
       "{{tableName}} already exists, will be overwritten": "{{tableName}} already exists, will be overwritten",

--- a/gui/docs/de/anonymization.md
+++ b/gui/docs/de/anonymization.md
@@ -1,1 +1,3 @@
-# TBD
+# Anonymization
+
+TBD

--- a/gui/docs/en/anonymization.md
+++ b/gui/docs/en/anonymization.md
@@ -1,1 +1,3 @@
-# TBD
+# Anonymization
+
+TBD

--- a/gui/src/ImportDataTab/FileLoadStep/FileLoadStep.tsx
+++ b/gui/src/ImportDataTab/FileLoadStep/FileLoadStep.tsx
@@ -1,12 +1,11 @@
 import { FileDoneOutlined, FileOutlined } from '@ant-design/icons';
-import { Divider, Typography, Upload } from 'antd';
+import { Divider, Upload } from 'antd';
 import React, { FunctionComponent, useCallback, useState } from 'react';
 import { useT } from '../../shared';
 import { File } from '../../types';
 import { ImportDataNavAnchor, ImportDataNavStep } from '../import-data-nav';
 
 const { Dragger } = Upload;
-const { Title } = Typography;
 
 export type FileLoadStepProps = {
   children: (data: FileLoadStepData) => React.ReactNode;
@@ -36,7 +35,6 @@ export const FileLoadStep: FunctionComponent<FileLoadStepProps> = ({ children })
     <>
       <div className="FileLoadStep import-data-step">
         <ImportDataNavAnchor step={ImportDataNavStep.CsvImport} status={file ? 'done' : 'active'} />
-        <Title level={3}>{t('Import table')}</Title>
         <Dragger
           accept=".csv,.tsv,.txt"
           fileList={[]}
@@ -50,7 +48,7 @@ export const FileLoadStep: FunctionComponent<FileLoadStepProps> = ({ children })
           showUploadList={false}
         >
           <p className="ant-upload-drag-icon">{lastCompletedImport ? <FileDoneOutlined /> : <FileOutlined />}</p>
-          <p className="ant-upload-text">{t('From CSV file')}</p>
+          <p className="ant-upload-text">{t('Select CSV file')}</p>
           <p className="ant-upload-hint">{dragPromptText}</p>
         </Dragger>
       </div>

--- a/gui/src/ImportDataTab/ImportStep/ImportStep.tsx
+++ b/gui/src/ImportDataTab/ImportStep/ImportStep.tsx
@@ -53,7 +53,7 @@ export const ImportStep: FunctionComponent<ImportProps> = ({ file, schema, aidCo
     <>
       <div className="ImportStep import-data-step">
         <ImportDataNavAnchor step={ImportDataNavStep.Import} />
-        <Title level={3}>{t('Import')}</Title>
+        <Title level={3}>{t('Select a name for the table')}</Title>
         <Form layout="inline" initialValues={{ tableName }} onValuesChange={({ tableName }) => setTableName(tableName)}>
           <Form.Item
             label={t('Table name')}

--- a/gui/src/ImportDataTab/import-data-help.tsx
+++ b/gui/src/ImportDataTab/import-data-help.tsx
@@ -1,7 +1,6 @@
 import { Typography } from 'antd';
 import React, { FunctionComponent } from 'react';
 import { Trans } from 'react-i18next';
-import { DocsLink } from '../DocsTab';
 import { TFunc, useT as useBaseT } from '../shared';
 import { ImportDataNavStep, useNavState } from './import-data-nav';
 
@@ -23,13 +22,11 @@ function CsvImportHelp() {
   const t = useT('CsvImportHelp');
   return (
     <div>
-      <Title level={4}>{t('CSV Import')}</Title>
+      <Title level={4}>{t('Select File')}</Title>
       <Paragraph t={t}>
-        <strong>Diffix Dashboards</strong> auto-detects the CSV delimiter, as well as the field type (text and numeric).
+        <strong>Diffix Dashboards</strong> auto-detects the CSV delimiter, as well as the field type (text, numeric and
+        timestamp).
         <br />
-        <DocsLink page="anonymization" section="load-table-from-csv">
-          Click here for details.
-        </DocsLink>
       </Paragraph>
     </div>
   );
@@ -49,13 +46,17 @@ function AidSelectionHelp() {
   const t = useT('AidSelectionHelp');
   return (
     <div>
-      <Title level={4}>{t('ID Selection')}</Title>
+      <Title level={4}>{t('Protected Entity')}</Title>
       <Paragraph t={t}>
         <strong>WARNING:</strong> If this configuration is not done correctly, the data will not be properly anonymized.
       </Paragraph>
       <Paragraph t={t}>
         If the data has one row per person (or other <em>protected entity</em>), then no entity identifier column need
-        be selected. Otherwise, select a column containing a unique ID per protected entity. TODO: link docs
+        be selected. Otherwise, select a column containing a unique ID per protected entity.
+      </Paragraph>
+      <Paragraph t={t}>
+        If the data is not associated with any protected entities, it can be imported into a public table. Such data
+        will not be anonymized.
       </Paragraph>
     </div>
   );
@@ -65,8 +66,12 @@ function ImportHelp() {
   const t = useT('ImportHelp');
   return (
     <div>
-      <Title level={4}>{t('Import')}</Title>
-      <Paragraph t={t}>Finalize import into the database. TODO: link docs</Paragraph>
+      <Title level={4}>{t('Table Name')}</Title>
+      <Paragraph t={t}>Select a name for the imported table.</Paragraph>
+      <Paragraph t={t}>
+        <strong>Diffix Dashboards</strong> will propose a name based on the CSV file name, adjusting it to match the
+        requirements of the underlying database. You may override the proposed name.
+      </Paragraph>
     </div>
   );
 }

--- a/gui/src/ImportDataTab/import-data-nav.tsx
+++ b/gui/src/ImportDataTab/import-data-nav.tsx
@@ -261,23 +261,23 @@ const ImportDataNavSteps = React.memo<{ steps: ImportDataNavStepState[]; focused
       >
         <Step
           status={status(ImportDataNavStep.CsvImport)}
-          title={mapText(t('CSV Import'), focusedStep === ImportDataNavStep.CsvImport)}
+          title={mapText(t('Select File'), focusedStep === ImportDataNavStep.CsvImport)}
           description={t('Load data from CSV')}
         />
         <Step
           status={status(ImportDataNavStep.DataPreview)}
           title={mapText(t('Data Preview'), focusedStep === ImportDataNavStep.DataPreview)}
-          description={t('Preview contents of file')}
+          description={t('Preview contents of the file')}
         />
         <Step
           status={status(ImportDataNavStep.AidSelection)}
-          title={mapText(t('ID Selection'), focusedStep === ImportDataNavStep.AidSelection)}
-          description={t('Select the entity identifier column')}
+          title={mapText(t('Protected Entity'), focusedStep === ImportDataNavStep.AidSelection)}
+          description={t('Identify the protected entity in the data')}
         />
         <Step
           status={status(ImportDataNavStep.Import)}
-          title={mapText(t('Import'), focusedStep === ImportDataNavStep.Import)}
-          description={t('Finalize import')}
+          title={mapText(t('Table Name'), focusedStep === ImportDataNavStep.Import)}
+          description={t('Select table name and finalize import')}
         />
       </Steps>
     );


### PR DESCRIPTION
Related to #46 but not that yet. I decided to split it into two baby steps - first just to clean stuff, remove stale keys, useless links, adjust the wording, labels and compose a minimalistic side-panel help.

The next step would be to see what should we have in the DocsTab documentation.