### PR TITLE
Prevent breaking syncs on the anonymized access db

### DIFF
--- a/src/main/metabase/api.ts
+++ b/src/main/metabase/api.ts
@@ -233,7 +233,7 @@ export async function removeSampleData(): Promise<void> {
 }
 
 export async function getAnonymizedAccessDbId(): Promise<number> {
-  const databases = (await get('/api/database')).data as Array<Database>;
+  const databases = (await get('/api/database')).data as Database[];
   return findAnonymizedAccessDbId(databases);
 }
 


### PR DESCRIPTION
Closes #80 

Actually, the syncs on cadence were disabled already, but the syncs on refresh were still stumbling upon illegal anonymized queries.

It seems that for Anonymized Access `/sync` instead of `/sync_schema` does the trick (updates the table lists), but doesn't cause illegal queries.

