### PR TITLE
Improve examples popup

### DIFF
--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -67,7 +67,8 @@
         "Cancel": "Cancel",
         "Click here to analyze in Metabase": "Click here to analyze in Metabase",
         "Examples for {{tableName}} under construction...": "Examples for {{tableName}} under construction...",
-        "Examples for {{tableName}} ready. Click to view": "Examples for {{tableName}} ready. Click to view"
+        "Examples for {{tableName}} ready. Click to view": "Examples for {{tableName}} ready. Click to view",
+        "Examples for {{tableName}} failed": "Examples for {{tableName}} failed"
       }
     }
   },

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -61,7 +61,7 @@
       "Columns: {{columns}}": "Columns: {{columns}}",
       "TableDropdown": {
         "New SQL query": "New SQL query",
-        "Table Overview": "Table Overview",
+        "Example SQL queries": "Example SQL queries",
         "Remove": "Remove",
         "Remove table `{{name}}`?": "Remove table `{{name}}`?",
         "Cancel": "Cancel",

--- a/docs/en/operation.md
+++ b/docs/en/operation.md
@@ -39,7 +39,7 @@ table name.
 
 ![](images/analyze_options.png#480)
 
-Select `New SQL query` to start writing a SQL query. Select `Example SQL queries` to see some sample queries and chart
+Select `New SQL query` to start writing a SQL query. Select `Example SQL queries` to see some sample queries and charts
 that are automatically built for you (this might take a while on first run). You can use Metabase to modify and extend
 the examples.
 

--- a/docs/en/operation.md
+++ b/docs/en/operation.md
@@ -39,7 +39,7 @@ table name.
 
 ![](images/analyze_options.png#480)
 
-Select `New SQL query` to start writing a SQL query. Select `Table Overview` to see some sample queries and chart
+Select `New SQL query` to start writing a SQL query. Select `Example SQL queries` to see some sample queries and chart
 that are automatically built for you (this might take a while on first run). You can use Metabase to modify and extend
 the examples.
 

--- a/src/AdminTab/TableList.tsx
+++ b/src/AdminTab/TableList.tsx
@@ -122,7 +122,7 @@ const TableDropdown: FunctionComponent<TableDropdownProps> = ({ table, onOpenMet
           }
         }}
       >
-        {t('Table Overview')}
+        {t('Example SQL queries')}
       </Menu.Item>
       <Popconfirm
         title={t('Remove table `{{name}}`?', { name: table.name })}

--- a/src/AdminTab/TableList.tsx
+++ b/src/AdminTab/TableList.tsx
@@ -6,8 +6,8 @@ import {
   QuestionCircleOutlined,
 } from '@ant-design/icons';
 import { Button, Dropdown, Menu, message, Popconfirm, Table, Tooltip } from 'antd';
-import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
-import { TFunc, useT } from '../shared-react';
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import { TFunc, useStaticValue, useT } from '../shared-react';
 import { ROW_INDEX_COLUMN } from '../shared/constants';
 import {
   getUniqueKey,
@@ -47,15 +47,15 @@ const TableDropdown: FunctionComponent<TableDropdownProps> = ({ table, onOpenMet
   const [examplesInProgress, setExamplesInProgress] = useState(false);
   const { getTableExamples, removeTable } = useTableActions();
 
-  const messageKey = useRef(getUniqueKey());
+  const messageKey = useStaticValue(() => getUniqueKey());
 
   useEffect(() => {
     const handleClickAnywhere = () => {
-      if (!examplesInProgress) message.destroy(messageKey.current);
+      if (!examplesInProgress) message.destroy(messageKey);
     };
     document.addEventListener('mousedown', handleClickAnywhere);
     return () => document.removeEventListener('mousedown', handleClickAnywhere);
-  }, [examplesInProgress]);
+  }, [examplesInProgress, messageKey]);
 
   const menu = (
     <Menu>
@@ -75,7 +75,7 @@ const TableDropdown: FunctionComponent<TableDropdownProps> = ({ table, onOpenMet
             () =>
               message.loading({
                 content: t('Examples for {{tableName}} under construction...', { tableName: table.name }),
-                key: messageKey.current,
+                key: messageKey,
                 duration: 0,
               }),
             1000,
@@ -89,7 +89,7 @@ const TableDropdown: FunctionComponent<TableDropdownProps> = ({ table, onOpenMet
 
             if (elapsed < 3000) {
               clearTimeout(messageTimeout);
-              message.destroy(messageKey.current);
+              message.destroy(messageKey);
               onOpenMetabaseTab(`collection/${examplesCollectionId}`);
             } else {
               message.success({
@@ -98,13 +98,13 @@ const TableDropdown: FunctionComponent<TableDropdownProps> = ({ table, onOpenMet
                     type="link"
                     onClick={() => {
                       onOpenMetabaseTab(`collection/${examplesCollectionId}`);
-                      message.destroy(messageKey.current);
+                      message.destroy(messageKey);
                     }}
                   >
                     {t('Examples for {{tableName}} ready. Click to view', { tableName: table.name })}
                   </Button>
                 ),
-                key: messageKey.current,
+                key: messageKey,
                 // We rely on `message.destroy` called on `handleClickAnywhere`.
                 duration: 0,
               });
@@ -112,7 +112,7 @@ const TableDropdown: FunctionComponent<TableDropdownProps> = ({ table, onOpenMet
           } catch (err) {
             message.error({
               content: t('Examples for {{tableName}} failed', { tableName: table.name }),
-              key: messageKey.current,
+              key: messageKey,
               // We rely on `message.destroy` called on `handleClickAnywhere`.
               duration: 0,
             });


### PR DESCRIPTION
Closes #171 .

I started with a version which destroys the popup on mouse hover, but I didn't like it too much. This is more complicated, but feels much nicer.

I considered moving the now swollen `Menu.Item` to its own component, but when I started that it became obvious that the coupling is too strong, the code resulted pretty ugly. But I can still do it if the weight of this `Menu.Item` is too big.

I also rename `Table Overview` as requested and handle the errors in case the examples fail to generate